### PR TITLE
Attach tooltip to a static element around icons

### DIFF
--- a/app/views/itineraries/_table.html.slim
+++ b/app/views/itineraries/_table.html.slim
@@ -6,7 +6,9 @@
         th = Itinerary.human_attribute_name(:end_address)
         th
           span.d-block.d-sm-none
-            span.fas.fa-info-circle data-bs-toggle='tooltip' title=t('itineraries.common.features')
+            span data-bs-toggle='tooltip' title=t('itineraries.common.features')
+              span.fas.fa-info-circle
+              span.visually-hidden = t('itineraries.common.features')
           span.d-none.d-sm-block = t('itineraries.common.features')
         - if edit
           th = t('helpers.actions')
@@ -21,15 +23,25 @@
           td
             .feature-icons
               - if itinerary.pink?
-                span.fas.fa-lock.feature-icon.fa-fw.text-pink data-bs-toggle='tooltip' title=Itinerary.human_attribute_name(:pink)
+                span data-bs-toggle='tooltip' title=Itinerary.human_attribute_name(:pink)
+                  span.fas.fa-lock.feature-icon.fa-fw.text-pink
+                  span.visually-hidden = Itinerary.human_attribute_name(:pink)
               - if itinerary.daily?
-                span.fas.fa-redo.feature-icon.fa-fw data-bs-toggle='tooltip' title=Itinerary.human_attribute_name(:daily)
+                span data-bs-toggle='tooltip' title=Itinerary.human_attribute_name(:daily)
+                  span.fas.fa-redo.feature-icon.fa-fw
+                  span.visually-hidden = Itinerary.human_attribute_name(:daily)
               - if itinerary.round_trip?
-                span.fas.fa-exchange-alt.feature-icon.fa-fw data-bs-toggle='tooltip' title=Itinerary.human_attribute_name(:round_trip)
+                span data-bs-toggle='tooltip' title=Itinerary.human_attribute_name(:round_trip)
+                  span.fas.fa-exchange-alt.feature-icon.fa-fw
+                  span.visually-hidden = Itinerary.human_attribute_name(:round_trip)
               - if itinerary.pets_allowed?
-                span.fas.fa-paw.feature-icon.fa-fw data-bs-toggle='tooltip' title=Itinerary.human_attribute_name(:pets_allowed)
+                span data-bs-toggle='tooltip' title=Itinerary.human_attribute_name(:pets_allowed)
+                  span.fas.fa-paw.feature-icon.fa-fw
+                  span.visually-hidden = Itinerary.human_attribute_name(:pets_allowed)
               - if itinerary.smoking_allowed?
-                span.fas.fa-smoking.feature-icon.fa-fw data-bs-toggle='tooltip' title=Itinerary.human_attribute_name(:smoking_allowed)
+                span data-bs-toggle='tooltip' title=Itinerary.human_attribute_name(:smoking_allowed)
+                  span.fas.fa-smoking.feature-icon.fa-fw
+                  span.visually-hidden = Itinerary.human_attribute_name(:smoking_allowed)
           - if edit
             td
               = link_to edit_itinerary_path(itinerary), class: 'btn btn-sm btn-secondary me-2' do


### PR DESCRIPTION
FA icons are replaced by svg after page load, so the code may end in
attaching an event to an element that will be removed